### PR TITLE
Generate a base class for FitsImage so that the algorithm can work directly on numpy arrays

### DIFF
--- a/pymoresane/beam_fit.py
+++ b/pymoresane/beam_fit.py
@@ -3,14 +3,14 @@ from scipy import ndimage
 from scipy.optimize import curve_fit
 
 
-def beam_fit(psf, psf_header):
+def beam_fit(psf, cdelt1, cdelt2):
     """
     The following contructs a restoring beam from the psf. This is accoplished by fitting an elliptical Gaussian to the
     central lobe of the PSF.
 
     INPUTS:
     psf         (no default):   Array containing the psf for the image in question.
-    psf_header  (no default):   Header of the psf.
+    cdelt1, cdelt2  (no default):   Header of the psf.
     """
 
     if psf.shape>512:
@@ -60,8 +60,8 @@ def beam_fit(psf, psf_header):
 
     clean_beam = clean_beam/np.max(clean_beam)
 
-    bmaj = 2*np.sqrt(2*np.log(2))*max(opt[1],opt[2])*psf_header['CDELT1']
-    bmin = 2*np.sqrt(2*np.log(2))*min(opt[1],opt[2])*psf_header['CDELT2']
+    bmaj = 2*np.sqrt(2*np.log(2))*max(opt[1],opt[2])*cdelt1
+    bmin = 2*np.sqrt(2*np.log(2))*min(opt[1],opt[2])*cdelt2
     bpa = np.degrees(opt[3])%360 - 90
 
     beam_params = [abs(bmaj), abs(bmin), bpa]

--- a/pymoresane/main.py
+++ b/pymoresane/main.py
@@ -612,12 +612,8 @@ class DataImage(object):
             self.restored = np.fft.fftshift(np.fft.irfft2(np.fft.rfft2(self.model)*np.fft.rfft2(clean_beam)))
         self.restored += self.residual
         self.restored = self.restored.astype(np.float32)
-        try:
-            self.img_hdr.set('BMAJ',beam_params[0])
-            self.img_hdr.set('BMIN',beam_params[1])
-            self.img_hdr.set('BPA',beam_params[2])
-        except Exception as e:
-            logger.error("Exception in writing beam parameters {}".format(e))
+
+        return beam_params
 
     def handle_input(self, input_hdr):
         """
@@ -647,7 +643,7 @@ class DataImage(object):
         """
         data = data.reshape(1, 1, data.shape[0], data.shape[0])
         new_file = pyfits.PrimaryHDU(data,self.img_hdu_list[0].header)
-        new_file.writeto("{}".format(name), clobber=True)
+        new_file.writeto("{}".format(name), overwrite=True)
 
     def make_logger(self, level="INFO"):
         """
@@ -726,6 +722,15 @@ class FitsImage(DataImage):
 
         self.img_hdu_list.close()
         self.psf_hdu_list.close()
+
+    def restore(self):
+        beam_params = super(FitsImage, self).restore()
+        try:
+            self.img_hdr.set('BMAJ',beam_params[0])
+            self.img_hdr.set('BMIN',beam_params[1])
+            self.img_hdr.set('BPA',beam_params[2])
+        except Exception as e:
+            logger.error("Exception in writing beam parameters {}".format(e))
 
 def main():
     

--- a/pymoresane/main.py
+++ b/pymoresane/main.py
@@ -613,9 +613,9 @@ class DataImage(object):
         self.restored += self.residual
         self.restored = self.restored.astype(np.float32)
         try:
-            self.img_hdu_list[0].header.update('BMAJ',beam_params[0])
-            self.img_hdu_list[0].header.update('BMIN',beam_params[1])
-            self.img_hdu_list[0].header.update('BPA',beam_params[2])
+            self.img_hdr.set('BMAJ',beam_params[0])
+            self.img_hdr.set('BMIN',beam_params[1])
+            self.img_hdr.set('BPA',beam_params[2])
         except Exception as e:
             logger.error("Exception in writing beam parameters {}".format(e))
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setup(name='pymoresane',
       author_email='jonosken@gmail.com',
       url='https://github.com/ratt-ru/PyMORESANE',
       packages=['pymoresane'],
-      requires=['numpy', 'scipy', 'pyfits', 'pycuda'],
+      requires=['numpy', 'scipy', 'astropy', 'pycuda'],
       scripts=['pymoresane/bin/runsane'],
       )


### PR DESCRIPTION
Hi There,

Many thanks for creating PyMORESANE.

I'm working on the TART radio telescope - its an open-source 24-element design that uses a RESTful API to get visibilities. (github.com/tmolteno/TART), and has a web front end, as well as a python imaging front end.

These changes allow us to use moresane as one of the imaging algorithms from the python imaging front end (it works, although I haven't tuned parameters yet.). 

Changes:
* Moved to astropy.io.fits from pyfits
* Add a new base class DataImage, that holds the methods for managing the data once its in arrays. This bypasses FITS files.
* Placed a try-except around some hdu header stuff in the restore method that was failing.
